### PR TITLE
Timeout on setpoint

### DIFF
--- a/cfg/Pid.cfg
+++ b/cfg/Pid.cfg
@@ -31,4 +31,6 @@ gen.add("coupling_ang_long",   bool_t,   0, "Enable coupling between angular and
 
 gen.add("controller_debug_enabled",   bool_t,   0, "Debug controller intermediate gains",  False)
 
+gen.add("controller_timeout",   double_t,   0, "Timeout on setpoint input signal",  0.2, 0, 10)
+
 exit(gen.generate(PACKAGE, "tracking_pid", "Pid"))

--- a/include/controller/controller_node.h
+++ b/include/controller/controller_node.h
@@ -60,6 +60,7 @@ double error_th = 0;
 // For timing
 ros::Time prev_time;
 ros::Duration delta_t;
+double controller_timeout;
 
 // Controller output
 double control_effort_long = 0.0;  // output of pid controller

--- a/include/controller/controller_node.h
+++ b/include/controller/controller_node.h
@@ -60,7 +60,7 @@ double error_th = 0;
 // For timing
 ros::Time prev_time;
 ros::Duration delta_t;
-double controller_timeout;
+ros::Duration controller_timeout;
 
 // Controller output
 double control_effort_long = 0.0;  // output of pid controller

--- a/src/controller_node.cpp
+++ b/src/controller_node.cpp
@@ -118,7 +118,7 @@ void poseCallback()
     return;
   }
 
-  if ((ros::Time::now() - goalPoint.pose.header.stamp).toSec() > controller_timeout)
+  if ((ros::Time::now() - goalPoint.pose.header.stamp) > controller_timeout)
   {
     ROS_INFO_STREAM_THROTTLE(1.0, "Timed out waiting for setpoint. Stopping control until new setpoint.");
     waiting_for_setpoint = true;
@@ -147,7 +147,7 @@ void reconfigure_callback(const tracking_pid::PidConfig& config)
 {
   pid_controller.configure(config);
   controller_debug_enabled = config.controller_debug_enabled;
-  controller_timeout = config.controller_timeout;
+  controller_timeout = ros::Duration(config.controller_timeout);
 }
 
 int main(int argc, char** argv)

--- a/src/controller_node.cpp
+++ b/src/controller_node.cpp
@@ -147,6 +147,7 @@ void reconfigure_callback(const tracking_pid::PidConfig& config)
 {
   pid_controller.configure(config);
   controller_debug_enabled = config.controller_debug_enabled;
+  controller_timeout = config.controller_timeout;
 }
 
 int main(int argc, char** argv)
@@ -166,7 +167,6 @@ int main(int argc, char** argv)
   node_priv.param<bool>("enabled_on_boot", enabled_on_boot, true);
   controller_enabled = enabled_on_boot;
   waiting_for_setpoint = true;
-  node_priv.param<double>("controller_timeout", controller_timeout, 0.1);
 
   // instantiate publishers & subscribers
   control_effort_pub = node.advertise<geometry_msgs::Twist>("move_base/cmd_vel", 1);


### PR DESCRIPTION
The controller holds on to its latest position setpoint and keeps publishing command velocities indefinitely. This PR proposes to put a timeout on the input. If we didn't receive any "trajectory point" input for x seconds, we switch back to the "waiting for setpoint" state (enabled, but idle), suspending the publishing of cmd vel until a new setpoint is received.